### PR TITLE
Throttle page/post requests.

### DIFF
--- a/src/router/onRouteActivate.js
+++ b/src/router/onRouteActivate.js
@@ -8,10 +8,7 @@ const onRouteActivateMiddleware = routes => (router, dependencies) => (
 	const routeSegment = routes.find(r => r.name === toState.name)
 
 	if (routeSegment && routeSegment.onActivate) {
-		const action = routeSegment.onActivate(
-			dependencies.store.getState(),
-			toState.params,
-		)
+		const action = routeSegment.onActivate(toState.params)
 
 		if (action) {
 			dependencies.store.dispatch(action)

--- a/src/router/onRouteActivate.js
+++ b/src/router/onRouteActivate.js
@@ -8,7 +8,10 @@ const onRouteActivateMiddleware = routes => (router, dependencies) => (
 	const routeSegment = routes.find(r => r.name === toState.name)
 
 	if (routeSegment && routeSegment.onActivate) {
-		const action = routeSegment.onActivate(toState.params)
+		const action = routeSegment.onActivate(
+			toState.params,
+			dependencies.store.getState(),
+		)
 
 		if (action) {
 			dependencies.store.dispatch(action)

--- a/src/router/routes.js
+++ b/src/router/routes.js
@@ -3,7 +3,8 @@ import { requestPage, requestPost } from 'store'
 const createPageRequest = name => ({ pageId = 1, tagName = '' }) =>
 	requestPage(name, pageId, tagName)
 
-const createPostRequest = ({ postId }) => requestPost('post', postId)
+const requestPostIfNeeded = ({ postId }, state) =>
+	!state.tumblr.posts[postId] && requestPost('post', postId)
 
 const routes = [
 	{
@@ -35,12 +36,12 @@ const routes = [
 	{
 		name: 'post',
 		path: '/post/:postId/:postSlug',
-		onActivate: createPostRequest,
+		onActivate: requestPostIfNeeded,
 	},
 	{
 		name: 'postWithoutSlug',
 		path: '/post/:postId',
-		onActivate: createPostRequest,
+		onActivate: requestPostIfNeeded,
 	},
 	{ name: 'ask', path: '/ask' },
 	{ name: 'downloads', path: '/downloads' },

--- a/src/router/routes.js
+++ b/src/router/routes.js
@@ -1,28 +1,26 @@
 import { requestPage, requestPost } from 'store'
 
-const requestPageIfNeeded = name => (state, { pageId = 1, tagName = '' }) =>
-	!state.tumblr.pages[`${tagName}${pageId}`] &&
+const createPageRequest = name => (state, { pageId = 1, tagName = '' }) =>
 	requestPage(name, pageId, tagName)
 
-const requestPostIfNeeded = (state, { postId }) =>
-	!state.tumblr.posts[postId] && requestPost('post', postId)
+const createPostRequest = (state, { postId }) => requestPost('post', postId)
 
 const routes = [
 	{
 		name: 'all',
 		path: '/',
-		onActivate: requestPageIfNeeded('all'),
+		onActivate: createPageRequest('all'),
 	},
 	{ name: 'all.index', path: 'page/1', forwardTo: 'all' },
 	{
 		name: 'all.page',
 		path: 'page/:pageId',
-		onActivate: requestPageIfNeeded('all.page'),
+		onActivate: createPageRequest('all.page'),
 	},
 	{
 		name: 'tag',
 		path: '/tagged/:tagName',
-		onActivate: requestPageIfNeeded('tag'),
+		onActivate: createPageRequest('tag'),
 	},
 	{
 		name: 'tag.index',
@@ -32,17 +30,17 @@ const routes = [
 	{
 		name: 'tag.page',
 		path: '/page/:pageId',
-		onActivate: requestPageIfNeeded('tag.page'),
+		onActivate: createPageRequest('tag.page'),
 	},
 	{
 		name: 'post',
 		path: '/post/:postId/:postSlug',
-		onActivate: requestPostIfNeeded,
+		onActivate: createPostRequest,
 	},
 	{
 		name: 'postWithoutSlug',
 		path: '/post/:postId',
-		onActivate: requestPostIfNeeded,
+		onActivate: createPostRequest,
 	},
 	{ name: 'ask', path: '/ask' },
 	{ name: 'downloads', path: '/downloads' },

--- a/src/router/routes.js
+++ b/src/router/routes.js
@@ -1,9 +1,9 @@
 import { requestPage, requestPost } from 'store'
 
-const createPageRequest = name => (state, { pageId = 1, tagName = '' }) =>
+const createPageRequest = name => ({ pageId = 1, tagName = '' }) =>
 	requestPage(name, pageId, tagName)
 
-const createPostRequest = (state, { postId }) => requestPost('post', postId)
+const createPostRequest = ({ postId }) => requestPost('post', postId)
 
 const routes = [
 	{

--- a/src/store/tumblr/requests.js
+++ b/src/store/tumblr/requests.js
@@ -19,8 +19,6 @@ const timeoutExists = key => {
 }
 
 export const requestPost = (route, postId) => dispatch => {
-	if (timeoutExists(`post/${postId}`)) return
-
 	dispatch({ type: REQUEST_POST, postId })
 
 	api.getPost(postId).then(({ post }) => {

--- a/src/store/tumblr/requests.js
+++ b/src/store/tumblr/requests.js
@@ -4,7 +4,23 @@ import { receivePage, receivePost, receivePosts } from './actions'
 import { REQUEST_PAGE, REQUEST_POST } from './actionTypes'
 import { transformPost } from './transformers'
 
+const timeouts = {}
+
+const timeoutExists = key => {
+	if (timeouts[key]) return true
+
+	timeouts[key] = true
+
+	setTimeout(() => {
+		timeouts[key] = false
+	}, 5 * 60 * 1000)
+
+	return false
+}
+
 export const requestPost = (route, postId) => dispatch => {
+	if (timeoutExists(`post/${postId}`)) return
+
 	dispatch({ type: REQUEST_POST, postId })
 
 	api.getPost(postId).then(({ post }) => {
@@ -13,6 +29,8 @@ export const requestPost = (route, postId) => dispatch => {
 }
 
 export const requestPage = (route, page, tag) => dispatch => {
+	if (timeoutExists(`page/${route}/${page}/${tag}`)) return
+
 	dispatch({ type: REQUEST_PAGE, page, tag })
 
 	api.getPosts(tag, page).then(({ posts, total_posts }) => {


### PR DESCRIPTION
For issue #4.

Added a simple throttling feature with a 5-minute timeout. If a user revisits a given page/post more than five minutes after they initially visited it, the page is re-fetched.

Need to consider whether it makes sense to do this for posts - it's much less likely that a post's content will change in between views.

Also need to consider whether it's worth comparing the newly requested page to the stored version, clearing _all_ cached pages if they don't match/throttling _any_ page request if they do match. No need to re-fetch page 2 if we know page 1 has not been changed since the original fetch.