### PR TITLE
Revert downloads page.

### DIFF
--- a/src/views/customPages/Downloads.js
+++ b/src/views/customPages/Downloads.js
@@ -1,7 +1,24 @@
 import React, { Fragment } from 'react'
 
-import { DownloadList } from 'components'
+import { Link, Page } from 'components'
 
-const Downloads = () => <DownloadList contentType="download" />
+const Downloads = () => (
+	<Page>
+		{({ styles }) => (
+			<Fragment>
+				<header className={styles.header}>
+					<h1>Downloads</h1>
+					<h3>Under construction</h3>
+				</header>
+				<p>
+					<Link routeName="tag" routeParams={{ tagName: 'downloads' }}>
+						For now, please click here to view the <strong>downloads</strong>&nbsp;
+						tag instead!
+					</Link>
+				</p>
+			</Fragment>
+		)}
+	</Page>
+)
 
 export default Downloads


### PR DESCRIPTION
Reverting this temporarily, so that we can release the Sims page now and add the Downloads page later.